### PR TITLE
Assorted fixes

### DIFF
--- a/src/utils/claan_page.py
+++ b/src/utils/claan_page.py
@@ -139,9 +139,8 @@ class ClaanPage:
                     )
                     st.metric(
                         label="Fortnight Number",
-                        value=st.session_state["fortnight_info"].get(
-                            "fortnight_number"
-                        ),
+                        value=st.session_state["fortnight_info"].get("fortnight_number")
+                        + 1,
                     )
                 with col_2:
                     st.metric(

--- a/src/utils/claan_page.py
+++ b/src/utils/claan_page.py
@@ -249,7 +249,7 @@ class ClaanPage:
                 key="history_button_refresh",
                 help="Click to refresh historical data",
             ):
-                get_historical_data(claan=self.claan)
+                get_historical_data.clear(claan=self.claan)
                 st.session_state[f"historical_{self.claan.name}"] = get_historical_data(
                     _session=Database.get_session(), claan=self.claan
                 )

--- a/src/utils/data/scores.py
+++ b/src/utils/data/scores.py
@@ -65,7 +65,7 @@ def get_claan_data(_session: Session, claan: Claan):
     }
 
 
-@st.cache_data
+@st.cache_data(ttl=43200)
 def get_historical_data(_session: Session, claan: Claan) -> None:
     season_start = get_season_start(_session=_session)
 

--- a/src/utils/data/stocks.py
+++ b/src/utils/data/stocks.py
@@ -67,7 +67,12 @@ def get_corporate_data(_session: Session, claan: Claan) -> Dict[str, float]:
     escrow_query = select(func.sum(Record.score)).where(Record.claan == company.claan)
     escrow = _session.execute(escrow_query).scalar_one()
 
-    quests_query = select(func.count()).select_from(Record).join(Task)
+    quests_query = (
+        select(func.count())
+        .select_from(Record)
+        .join(Task)
+        .where(Record.claan == company.claan)
+    )
     quests = _session.execute(quests_query).scalar_one()
 
     return {


### PR DESCRIPTION
## Description
Multiple fixes reported after launch of season 5.

## Changelog

- Fixed record history on Claan page not loading, closes #26
- Fixed fortnight number showing 0 for first fortnight, now prints with value + 1, closes #28
- Fixed tasks completed count on Claan page showing sum all tasks completed for all Claans, not just the specific Claan, closes #29  
