### PR TITLE
Miscellaenous Fixes and Improvements

### DIFF
--- a/Claan-Portal.py
+++ b/Claan-Portal.py
@@ -109,7 +109,7 @@ Welcome to Season 5 of Claans, 'Corporate Claash', where this time we'll be figh
 Every Claan is a corporation, and Claan Members are Board Members.
 \nEvery time you complete a quest you are given a reward which is then locked up in escrow.
 \nAt the end of each fortnight, Board Member votes will be tallied to decide whether those funds should go straight into the Claan's Stash, or divided amongst the shareholders.
-\nClaans that pay out enough money will see their share price increase, but those that withold will instead see it drop.
+\nClaans that pay out enough money will see their share price increase, but those that withhold will instead see it drop.
             """
         )
 
@@ -132,9 +132,9 @@ Each Claan has been issues 50 shares initially, with 2 shares given to each Boar
     with st.container():
         st.header("FAQ")
 
-        st.subheader("What happens if we vote 'Withold'?")
+        st.subheader("What happens if we vote 'Withhold'?")
         st.write(
-            "If a Claan votes to withold funds, then all money in escrow will go straight into the Stash, but shareholders won't receive any more and the share price will decrease."
+            "If a Claan votes to withhold funds, then all money in escrow will go straight into the Stash, but shareholders won't receive any more and the share price will decrease."
         )
 
         st.subheader("What happens if we vote 'Payout'?")

--- a/src/models/market/portfolio.py
+++ b/src/models/market/portfolio.py
@@ -18,6 +18,12 @@ class BoardVote(Enum):
     WITHOLD = 2
     PAYOUT = 3
 
+    def __str__(self):
+        if self == BoardVote.WITHOLD:
+            return "WITHHOLD"
+        else:
+            return self.name
+
 
 class Portfolio(Base):
     __tablename__ = "portfolios"

--- a/src/utils/claan_page.py
+++ b/src/utils/claan_page.py
@@ -14,6 +14,7 @@ from src.utils.data.stocks import (
     get_ipo_count,
     get_owned_shares,
     get_portfolio,
+    get_shares_for_sale,
     sell_share,
     update_vote,
 )
@@ -110,6 +111,16 @@ class ClaanPage:
             st.session_state["instruments"] = get_instruments(
                 _session=st.session_state["db_session"]
             )
+
+        if "for_sale_count" not in st.session_state:
+            LOGGER.info("Loading `for_sale_count`")
+            st.session_state["for_sale_count"] = {
+                instrument: get_shares_for_sale(
+                    _session=st.session_state["db_session"],
+                    instrument_id=instrument.id,
+                )
+                for instrument in st.session_state["instruments"]
+            }
 
         self.build_page()
 
@@ -256,6 +267,12 @@ class ClaanPage:
                                         "owned_count"
                                     ],
                                 )
+                                st.metric(
+                                    label="For sale",
+                                    value=st.session_state["for_sale_count"][
+                                        instrument
+                                    ],
+                                )
                                 if st.button(
                                     label="BUY",
                                     key=f"share_buy_{instrument}",
@@ -288,7 +305,7 @@ class ClaanPage:
                     st.session_state["portfolio"] = portfolio = st.session_state[
                         f"portfolios_{self.claan.name}"
                     ][user.id]
-                    with st.form(key="form_activities"):
+                    with st.form(key="form_wallet"):
                         st.header("Wallet")
                         st.metric(
                             label="Wallet Cash",

--- a/src/utils/claan_page.py
+++ b/src/utils/claan_page.py
@@ -285,6 +285,7 @@ class ClaanPage:
                                             ][user.id],
                                             instrument=instrument,
                                         )
+                                        st.rerun()
                                     if st.button(
                                         label="SELL",
                                         key=f"share_sell_{instrument}",
@@ -296,6 +297,7 @@ class ClaanPage:
                                             ][user.id],
                                             instrument=instrument,
                                         )
+                                        st.rerun()
 
                         st.write("Limited to 5 shares of each Company")
                         st.write(

--- a/src/utils/claan_page.py
+++ b/src/utils/claan_page.py
@@ -296,13 +296,13 @@ class ClaanPage:
                         )
                         st.metric(
                             label="Current Vote",
-                            value=portfolio.board_vote.name.title(),
+                            value=str(portfolio.board_vote).title(),
                         )
                         st.radio(
                             label="Board Vote",
                             key="portfolio_vote",
                             options=list(BoardVote),
-                            format_func=lambda vote_type: vote_type.name.title(),
+                            format_func=lambda vote_type: str(vote_type).title(),
                             index=list(BoardVote).index(portfolio.board_vote),
                         )
                         st.form_submit_button(

--- a/src/utils/claan_page.py
+++ b/src/utils/claan_page.py
@@ -255,46 +255,47 @@ class ClaanPage:
 
                         for instrument, col in cols:
                             with col:
-                                st.metric(
-                                    label=instrument.ticker,
-                                    value=f"${instrument.price}",
-                                )
-                                st.metric(
-                                    label="Owned",
-                                    value=st.session_state[
-                                        f"owned_shares_{self.claan.name}"
-                                    ][portfolio.id][instrument.company.claan][
-                                        "owned_count"
-                                    ],
-                                )
-                                st.metric(
-                                    label="For sale",
-                                    value=st.session_state["for_sale_count"][
-                                        instrument
-                                    ],
-                                )
-                                if st.button(
-                                    label="BUY",
-                                    key=f"share_buy_{instrument}",
-                                ):
-                                    buy_share(
-                                        _session=st.session_state["db_session"],
-                                        portfolio=st.session_state[
-                                            f"portfolios_{self.claan.name}"
-                                        ][user.id],
-                                        instrument=instrument,
+                                with st.container(border=True):
+                                    st.metric(
+                                        label=instrument.ticker,
+                                        value=f"${instrument.price}",
                                     )
-                                if st.button(
-                                    label="SELL",
-                                    key=f"share_sell_{instrument}",
-                                ):
-                                    sell_share(
-                                        _session=st.session_state["db_session"],
-                                        portfolio=st.session_state[
-                                            f"portfolios_{self.claan.name}"
-                                        ][user.id],
-                                        instrument=instrument,
+                                    st.metric(
+                                        label="Owned",
+                                        value=st.session_state[
+                                            f"owned_shares_{self.claan.name}"
+                                        ][portfolio.id][instrument.company.claan][
+                                            "owned_count"
+                                        ],
                                     )
+                                    st.metric(
+                                        label="For sale",
+                                        value=st.session_state["for_sale_count"][
+                                            instrument
+                                        ],
+                                    )
+                                    if st.button(
+                                        label="BUY",
+                                        key=f"share_buy_{instrument}",
+                                    ):
+                                        buy_share(
+                                            _session=st.session_state["db_session"],
+                                            portfolio=st.session_state[
+                                                f"portfolios_{self.claan.name}"
+                                            ][user.id],
+                                            instrument=instrument,
+                                        )
+                                    if st.button(
+                                        label="SELL",
+                                        key=f"share_sell_{instrument}",
+                                    ):
+                                        sell_share(
+                                            _session=st.session_state["db_session"],
+                                            portfolio=st.session_state[
+                                                f"portfolios_{self.claan.name}"
+                                            ][user.id],
+                                            instrument=instrument,
+                                        )
 
                         st.write("Limited to 5 shares of each Company")
                         st.write(

--- a/src/utils/claan_page.py
+++ b/src/utils/claan_page.py
@@ -278,26 +278,26 @@ class ClaanPage:
                                         label="BUY",
                                         key=f"share_buy_{instrument}",
                                     ):
-                                        buy_share(
+                                        if buy_share(
                                             _session=st.session_state["db_session"],
                                             portfolio=st.session_state[
                                                 f"portfolios_{self.claan.name}"
                                             ][user.id],
                                             instrument=instrument,
-                                        )
-                                        st.rerun()
+                                        ):
+                                            st.rerun()
                                     if st.button(
                                         label="SELL",
                                         key=f"share_sell_{instrument}",
                                     ):
-                                        sell_share(
+                                        if sell_share(
                                             _session=st.session_state["db_session"],
                                             portfolio=st.session_state[
                                                 f"portfolios_{self.claan.name}"
                                             ][user.id],
                                             instrument=instrument,
-                                        )
-                                        st.rerun()
+                                        ):
+                                            st.rerun()
 
                         st.write("Limited to 5 shares of each Company")
                         st.write(

--- a/src/utils/data/stocks.py
+++ b/src/utils/data/stocks.py
@@ -242,15 +242,15 @@ def grant_share_to_user(_session: Session, portfolio: Portfolio) -> None:
 
 
 @st.cache_data(ttl=600)
-def get_shares_for_sale(_session: Session, instrument_id: int) -> List[Share]:
+def get_shares_for_sale(_session: Session, instrument_id: int) -> int:
     share_query = (
-        select(Share)
-        .where(not Share.owner_id)
+        select(func.count(Share.id))
+        .where(Share.owner_id.is_(None))
         .where(Share.instrument_id == instrument_id)
     )
-    shares = _session.execute(share_query).scalars().all()
+    count = _session.execute(share_query).scalar_one()
 
-    return shares
+    return count
 
 
 def get_all_shares(_session: Session) -> List[Share]:

--- a/src/utils/data/stocks.py
+++ b/src/utils/data/stocks.py
@@ -367,6 +367,7 @@ def buy_share(_session: Session, portfolio: Portfolio, instrument: Instrument) -
             )
         )
         share.owner_id = portfolio.id
+        share.ipo = False
         portfolio.cash -= instrument.price
 
         nested.commit()

--- a/src/utils/data/stocks.py
+++ b/src/utils/data/stocks.py
@@ -87,8 +87,8 @@ def get_corporate_data(_session: Session, claan: Claan) -> Dict[str, float]:
 
     return {
         "instrument": instrument,
-        "funds": funds,
-        "escrow": escrow,
+        "funds": round(funds or 0.0, 2),
+        "escrow": round(escrow or 0.0, 2),
         "task_count": quests,
     }
 
@@ -384,6 +384,13 @@ def buy_share(_session: Session, portfolio: Portfolio, instrument: Instrument) -
         LOGGER.info(f"Refreshing owned shares for {portfolio.user.claan.value}")
         st.session_state[f"owned_shares_{portfolio.user.claan.name}"] = (
             get_owned_shares(_session=_session, claan=portfolio.user.claan)
+        )
+
+    get_shares_for_sale.clear(instrument_id=instrument.id)
+    if "for_sale_count" in st.session_state:
+        LOGGER.info(f"Refreshing shares for sale count for {instrument.ticker}")
+        st.session_state["for_sale_count"][instrument] = get_shares_for_sale(
+            _session=st.session_state["db_session"], instrument_id=instrument.id
         )
 
     _session.commit()

--- a/src/utils/data/stocks.py
+++ b/src/utils/data/stocks.py
@@ -351,6 +351,7 @@ def buy_share(_session: Session, portfolio: Portfolio, instrument: Instrument) -
                     f"User {portfolio.user.name} attempted to buy share but none left to buy."
                 )
                 st.error("No shares left to buy!")
+                return
 
         LOGGER.info(
             f"User {portfolio.user.name} buying {instrument.ticker}, successful. Saving..."

--- a/src/utils/data/stocks.py
+++ b/src/utils/data/stocks.py
@@ -491,7 +491,7 @@ def process_escrow(_session: Session) -> None:
         if results[BoardVote.PAYOUT] >= results[BoardVote.WITHOLD]:
             payout(_session, company)
         else:
-            withold(_session, company)
+            withhold(_session, company)
 
         LOGGER.info("Clearing relevant function caches and reloading data")
 
@@ -627,7 +627,7 @@ def payout(_session: Session, company: Company) -> None:
         print("")
 
 
-def withold(_session: Session, company: Company) -> None:
+def withhold(_session: Session, company: Company) -> None:
     decimal_context = getcontext()
     decimal_context.prec = 28  # if result of round would require higher precision than this to represent, then exception is raised, hence high value
     decimal_context.traps[FloatOperation] = True


### PR DESCRIPTION
Fixes:

1. Added missing `return` in `buy_share` that was causing an exception when trying to buy a share when none were left for sale. Closes #44 
2. Fixed shares not being removed from IPO when bought. Closes #42 
3. Fixed typo, changing 'withold' to 'withhold'. Closes #34 
4. Fixed rounding errors when displaying some prices

Improvements:

1. Added count of shares for sale to market section of claan page. Closes #43 
2. Added container around market stocks for better clarity
3. Added conditional rerun of claan page when buying or selling shares so that data updates properly