### PR TITLE
Fix for error when buying shares

### DIFF
--- a/src/utils/data/stocks.py
+++ b/src/utils/data/stocks.py
@@ -343,6 +343,7 @@ def buy_share(_session: Session, portfolio: Portfolio, instrument: Instrument) -
                 select(Share)
                 .where(Share.instrument == instrument)
                 .where(Share.owner_id.is_(None))
+                .limit(1)
             )
             try:
                 share = _session.execute(share_query).scalar_one()


### PR DESCRIPTION
This error occurred when trying to buy a share but none were left in IPO.
Adding a limit to the select to get the next un-owned share fixes.